### PR TITLE
Update util_functions.sh for improved magiskboot_path support.

### DIFF
--- a/util_functions.sh
+++ b/util_functions.sh
@@ -32,8 +32,8 @@ hexpatch_deleteprop() {
     search_hex=$(echo -n "$search_string" | xxd -p | tr '[:lower:]' '[:upper:]') # Hex representation in uppercase
 
     # Path to magiskboot
-    magiskboot_path=$(which magiskboot 2>/dev/null || find /data/adb /data/data/me.bmax.apatch/patch/ -name magiskboot 2>/dev/null)
-
+    magiskboot_path=$(which magiskboot 2>/dev/null || find /data/adb /data/data/me.bmax.apatch/patch/ -name magiskboot -print -quit 2>/dev/null)
+    
     # Generate a random LOWERCASE alphanumeric string of the required length, but only using 0-9 and a-f
     replacement_string=$(cat /dev/urandom | tr -dc '0-9a-f' | head -c ${#search_string})
 
@@ -86,8 +86,8 @@ hexpatch_replaceprop() {
     replace_hex=$(echo -n "$new_string" | xxd -p | tr '[:lower:]' '[:upper:]')   # Hex representation of the new string, also uppercase
 
     # Path to magiskboot
-    magiskboot_path=$(which magiskboot 2>/dev/null || find /data/adb /data/data/me.bmax.apatch/patch/ -name magiskboot 2>/dev/null)
-
+    magiskboot_path=$(which magiskboot 2>/dev/null || find /data/adb /data/data/me.bmax.apatch/patch/ -name magiskboot -print -quit 2>/dev/null)
+    
     # Get property list from search string
     # Then get a list of property file names using resetprop -Z and pipe it to find
     getprop | grep "$search_string" | cut -d'[' -f2 | cut -d']' -f1 | while read prop_name; do


### PR DESCRIPTION
Automatically pick one path and works on it when multiple magiskboot exists. Fix working for device with multiple root implementation or old inconsistent traces from ex-root files.