### PR TITLE
fix(props): resetprop-rs --init routing and AVB image size

### DIFF
--- a/config.prop
+++ b/config.prop
@@ -1,0 +1,5 @@
+# Download resetprop-rs for enhanced stealth hexpatch?
+# true = download during install (default)
+# false = skip, use built-in magiskboot hexpatch
+# Volume keys override this at install time.
+download_resetprop_rs=true

--- a/customize.sh
+++ b/customize.sh
@@ -128,8 +128,84 @@ if [ "$API" -lt 29 ]; then
   abort "! Only support Android 10+ devices"
 fi
 
+# Optional resetprop-rs download
+RESETPROP_RS_URL="https://github.com/Enginex0/resetprop-rs/releases/latest/download"
+case "$ARCH" in
+  arm64) RESETPROP_RS_ASSET="resetprop-arm64-v8a" ;;
+  arm)   RESETPROP_RS_ASSET="resetprop-armeabi-v7a" ;;
+  *)     RESETPROP_RS_ASSET="" ;;
+esac
+
+if [ -n "$RESETPROP_RS_ASSET" ]; then
+  # Read config.prop preference
+  _cfg_val=$(grep -s '^download_resetprop_rs=' "$MODPATH/config.prop" | cut -d= -f2)
+
+  ui_print "- Download resetprop-rs for enhanced stealth hexpatch?"
+  ui_print "  Vol+ = Download | Vol- = Skip (15s timeout)"
+
+  _vol_tmp="$TMPDIR/vol_key"
+  _vol_sec=15
+  : > "$_vol_tmp"
+  getevent -qlc 1 > "$_vol_tmp" 2>/dev/null &
+  _ge_pid=$!
+
+  DO_DOWNLOAD=""
+  while [ "$_vol_sec" -gt 0 ]; do
+    sleep 1
+    if ! kill -0 "$_ge_pid" 2>/dev/null; then
+      _key=$(awk '/KEY_/{print $3}' "$_vol_tmp" 2>/dev/null)
+      case "$_key" in
+        KEY_VOLUMEUP)   DO_DOWNLOAD=true; break ;;
+        KEY_VOLUMEDOWN) DO_DOWNLOAD=false; break ;;
+      esac
+      : > "$_vol_tmp"
+      getevent -qlc 1 > "$_vol_tmp" 2>/dev/null &
+      _ge_pid=$!
+    fi
+    _vol_sec=$((_vol_sec - 1))
+  done
+
+  kill "$_ge_pid" 2>/dev/null
+  wait "$_ge_pid" 2>/dev/null
+  rm -f "$_vol_tmp"
+
+  # Timeout — fall back to config.prop
+  if [ -z "$DO_DOWNLOAD" ]; then
+    case "$_cfg_val" in
+      false|0|off) DO_DOWNLOAD=false ;;
+      *)           DO_DOWNLOAD=true ;;
+    esac
+  fi
+
+  if [ "$DO_DOWNLOAD" = true ]; then
+    ui_print "- Downloading resetprop-rs ($RESETPROP_RS_ASSET)..."
+    _dl_ok=false
+    if wget -qO "$MODPATH/resetprop-rs" "$RESETPROP_RS_URL/$RESETPROP_RS_ASSET" 2>/dev/null; then
+      _dl_ok=true
+    elif curl -sLo "$MODPATH/resetprop-rs" "$RESETPROP_RS_URL/$RESETPROP_RS_ASSET" 2>/dev/null; then
+      _dl_ok=true
+    fi
+
+    if [ "$_dl_ok" = true ]; then
+      chmod 755 "$MODPATH/resetprop-rs"
+      if "$MODPATH/resetprop-rs" -h >/dev/null 2>&1; then
+        ui_print "- resetprop-rs installed successfully"
+      else
+        ui_print "! resetprop-rs binary failed smoke test, removing"
+        rm -f "$MODPATH/resetprop-rs"
+      fi
+    else
+      ui_print "! Download failed, falling back to built-in hexpatch"
+      rm -f "$MODPATH/resetprop-rs"
+    fi
+  else
+    ui_print "- Skipping resetprop-rs, using built-in hexpatch"
+  fi
+fi
+
 # Set Module permissions
 set_perm_recursive "$MODPATH" 0 0 0755 0644
+[ -f "$MODPATH/resetprop-rs" ] && chmod 755 "$MODPATH/resetprop-rs"
 
 # Running the service early using busybox
 [ -f "$MODPATH/service.sh" ] && busybox sh "$MODPATH/service.sh" 2>&1

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -4,7 +4,7 @@ MODPATH="${0%/*}"
 MODNAME="${MODPATH##*/}"
 MAGISKTMP="$(magisk --path)" || MAGISKTMP=/sbin
 
-if [ "$(magisk -V)" -lt 26302 ] || [ "$(/data/adb/ksud -V)" -lt 10818 ]; then
+if [ "$(magisk -V)" -lt 26302 ] || { [ -x /data/adb/ksud ] && [ "$(/data/adb/ksud -V)" -lt 10818 ]; }; then
     touch "$MODPATH/disable"
 fi
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Build, package, deploy, and verify sensitive-props module.
+# Usage: ./scripts/package.sh [flags]
+#
+# Examples:
+#   ./scripts/package.sh                               # package ZIP
+#   ./scripts/package.sh --deploy --reboot              # package, push, install, reboot
+#   ./scripts/package.sh --deploy --verify              # deploy + verify props via adb
+#   ./scripts/package.sh --verify                       # verify-only (no build/deploy)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUT_DIR="$PROJECT_ROOT/out"
+
+DEPLOY=false
+REBOOT=false
+VERIFY=false
+CLEAN=false
+TRACE=false
+ROOT_PROVIDER="ksu"
+
+red()    { printf '\033[0;31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[0;32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[0;33m%s\033[0m\n' "$*"; }
+bold()   { printf '\033[1m%s\033[0m\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Package options:
+  --clean            Remove previous builds before packaging
+
+Deploy options:
+  --deploy           Push ZIP to device and install
+  --reboot           Reboot device after install
+  --verify           Check module state and spoofed properties
+  --root PROVIDER    Root provider: ksu (default), magisk, apatch
+
+Misc:
+  -v, --verbose      Print every command as it runs (set -x)
+  --help             Show this help
+EOF
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --clean)      CLEAN=true; shift ;;
+        --deploy)     DEPLOY=true; shift ;;
+        --reboot)     REBOOT=true; shift ;;
+        --verify)     VERIFY=true; shift ;;
+        -v|--verbose) TRACE=true; shift ;;
+        --root)       ROOT_PROVIDER="$2"; shift 2 ;;
+        --help|-h)    usage ;;
+        *)            red "Unknown flag: $1"; usage ;;
+    esac
+done
+
+[[ "$TRACE" == true ]] && set -x
+
+case "$ROOT_PROVIDER" in
+    ksu)     INSTALL_CMD="ksud module install" ;;
+    magisk)  INSTALL_CMD="magisk --install-module" ;;
+    apatch)  INSTALL_CMD="/data/adb/apd module install" ;;
+    *)       red "Unknown root provider: $ROOT_PROVIDER"; exit 1 ;;
+esac
+
+MODULE_ID=$(grep '^id=' "$PROJECT_ROOT/module.prop" | cut -d= -f2)
+MODULE_VER=$(grep '^version=' "$PROJECT_ROOT/module.prop" | cut -d= -f2)
+
+MODULE_FILES=(
+    META-INF
+    customize.sh
+    service.sh
+    post-fs-data.sh
+    util_functions.sh
+    module.prop
+    oem.rc
+    sepolicy.rule
+    uninstall.sh
+    config.prop
+)
+
+package_zip() {
+    [[ "$CLEAN" == true ]] && rm -rf "$OUT_DIR"
+    mkdir -p "$OUT_DIR"
+
+    local zip_name="${MODULE_ID}-${MODULE_VER}.zip"
+    local zip_path="$OUT_DIR/$zip_name"
+
+    rm -f "$zip_path"
+
+    bold "==> Packaging $zip_name"
+
+    local missing=false
+    for f in "${MODULE_FILES[@]}"; do
+        if [[ ! -e "$PROJECT_ROOT/$f" ]]; then
+            red "    Missing: $f"
+            missing=true
+        fi
+    done
+    [[ "$missing" == true ]] && exit 1
+
+    (cd "$PROJECT_ROOT" && zip -r9 "$zip_path" "${MODULE_FILES[@]}" -x '*.DS_Store' '*.swp')
+
+    local size
+    size=$(du -h "$zip_path" | cut -f1)
+    green "    $zip_name ($size)"
+}
+
+deploy_zip() {
+    local zip
+    zip=$(ls -t "$OUT_DIR"/${MODULE_ID}-*.zip 2>/dev/null | head -1)
+
+    if [[ -z "$zip" ]]; then
+        red "No ZIP found in $OUT_DIR"
+        exit 1
+    fi
+
+    if ! adb get-state &>/dev/null; then
+        red "No ADB device connected"
+        exit 1
+    fi
+
+    local name
+    name=$(basename "$zip")
+    bold "==> Deploying $name"
+    adb push "$zip" /data/local/tmp/module.zip
+    adb shell "su -c '$INSTALL_CMD /data/local/tmp/module.zip'"
+    green "    Installed via $ROOT_PROVIDER"
+
+    if [[ "$REBOOT" == true ]]; then
+        bold "==> Rebooting"
+        adb reboot
+        echo "    Waiting for device..."
+        adb wait-for-device
+        sleep 15
+    fi
+}
+
+verify_device() {
+    bold "==> Verification"
+
+    if ! adb get-state &>/dev/null; then
+        red "No ADB device connected"
+        exit 1
+    fi
+
+    # Module presence
+    local mod_active
+    mod_active=$(adb shell "su -c '[ -d /data/adb/modules/${MODULE_ID} ] && echo yes || echo no'")
+    if [[ "$mod_active" == *"yes"* ]]; then
+        green "    Module: installed"
+    else
+        red "    Module: not found"
+        return
+    fi
+
+    local disabled
+    disabled=$(adb shell "su -c '[ -f /data/adb/modules/${MODULE_ID}/disable ] && echo yes || echo no'")
+    [[ "$disabled" == *"yes"* ]] && yellow "    Module: DISABLED"
+
+    local rp_rs
+    rp_rs=$(adb shell "su -c '[ -x /data/adb/modules/${MODULE_ID}/resetprop-rs ] && echo yes || echo no'")
+    if [[ "$rp_rs" == *"yes"* ]]; then
+        green "    resetprop-rs: present"
+    else
+        yellow "    resetprop-rs: not present (using magiskboot fallback)"
+    fi
+
+    # Key property checks
+    echo "    --- Property Checks ---"
+    local checks=(
+        "ro.boot.verifiedbootstate:green"
+        "ro.boot.vbmeta.device_state:locked"
+        "ro.debuggable:0"
+        "ro.secure:1"
+        "ro.adb.secure:1"
+        "sys.oem_unlock_allowed:0"
+    )
+
+    local pass=0 fail=0
+    for check in "${checks[@]}"; do
+        local prop="${check%%:*}"
+        local expected="${check##*:}"
+        local actual
+        actual=$(adb shell "getprop $prop" 2>/dev/null | tr -d '\r\n')
+
+        if [[ "$actual" == "$expected" ]]; then
+            green "    $prop = $actual"
+            pass=$((pass + 1))
+        elif [[ -z "$actual" ]]; then
+            echo "    $prop = (empty/unset)"
+            pass=$((pass + 1))
+        else
+            red "    $prop = $actual (expected: $expected)"
+            fail=$((fail + 1))
+        fi
+    done
+
+    # Build tags/type across partitions
+    local tag_issues=0
+    for prefix in system vendor product; do
+        local tags
+        tags=$(adb shell "getprop ro.${prefix}.build.tags" 2>/dev/null | tr -d '\r\n')
+        [[ -n "$tags" ]] && [[ "$tags" != "release-keys" ]] && {
+            red "    ro.${prefix}.build.tags = $tags"
+            tag_issues=$((tag_issues + 1))
+        }
+        local btype
+        btype=$(adb shell "getprop ro.${prefix}.build.type" 2>/dev/null | tr -d '\r\n')
+        [[ -n "$btype" ]] && [[ "$btype" != "user" ]] && {
+            red "    ro.${prefix}.build.type = $btype"
+            tag_issues=$((tag_issues + 1))
+        }
+    done
+    [[ "$tag_issues" -eq 0 ]] && green "    Build tags/type: all clean"
+
+    # Custom ROM trace scan
+    local traces
+    traces=$(adb shell "getprop" 2>/dev/null | grep -icE 'lineage|crdroid|evolution|grapheneos|paranoid|calyxos' || true)
+    if [[ "$traces" -eq 0 ]]; then
+        green "    ROM traces: none detected"
+    else
+        yellow "    ROM traces: $traces properties still visible"
+    fi
+
+    echo ""
+    echo "    Results: $pass passed, $fail failed"
+}
+
+# --- Main ---
+echo ""
+bold "sensitive-props package pipeline"
+echo ""
+
+if [[ "$VERIFY" == true ]] && [[ "$DEPLOY" == false ]]; then
+    verify_device
+else
+    package_zip
+
+    [[ "$DEPLOY" == true ]] && deploy_zip
+    [[ "$VERIFY" == true ]] && verify_device
+fi
+
+echo ""
+green "Done."

--- a/service.sh
+++ b/service.sh
@@ -150,8 +150,7 @@ missing_resetprop ro.boot.vbmeta.hash_alg sha256
 force_resetprop ro.boot.vbmeta.device_state locked
 force_resetprop ro.boot.vbmeta.invalidate_on_error yes
 
-# Dynamic vbmeta_size -- use partition byte size with A/B slot suffix + multi-path fallback
-# Thanks to Enginex0
+# AVB image size from vbmeta partition header (not raw partition size)
 slot_suffix=$(getprop ro.boot.slot_suffix 2>/dev/null)
 VBMETA_SIZE=""
 for candidate in \
@@ -159,11 +158,17 @@ for candidate in \
     "/dev/block/by-name/vbmeta" \
     "/dev/block/by-name/vbmeta_a" \
     "/dev/block/by-name/vbmeta_b"; do
-    if [ -b "$candidate" ]; then
-        VBMETA_SIZE=$(blockdev --getsize64 "$candidate" 2>/dev/null)
-        [ -n "$VBMETA_SIZE" ] && [ "$VBMETA_SIZE" -gt 0 ] 2>/dev/null && break
-        VBMETA_SIZE=""
-    fi
+    [ -b "$candidate" ] || continue
+    avb_magic=$(dd if="$candidate" bs=1 count=4 2>/dev/null)
+    [ "$avb_magic" = "AVB0" ] || continue
+    # auth_data_block_size (offset 12) + aux_data_block_size (offset 20), both big-endian u64
+    auth_hex=$(dd if="$candidate" bs=1 skip=12 count=8 2>/dev/null | od -A n -t x1 | tr -d ' \n')
+    aux_hex=$(dd if="$candidate" bs=1 skip=20 count=8 2>/dev/null | od -A n -t x1 | tr -d ' \n')
+    auth_hex=$(echo "$auth_hex" | sed 's/^0*//')
+    aux_hex=$(echo "$aux_hex" | sed 's/^0*//')
+    VBMETA_SIZE=$((256 + 0x${auth_hex:-0} + 0x${aux_hex:-0}))
+    [ "$VBMETA_SIZE" -gt 256 ] 2>/dev/null && break
+    VBMETA_SIZE=""
 done
-force_resetprop "ro.boot.vbmeta.size" "${VBMETA_SIZE:-4096}"
+missing_resetprop "ro.boot.vbmeta.size" "${VBMETA_SIZE:-4096}"
 

--- a/service.sh
+++ b/service.sh
@@ -21,7 +21,7 @@ until [ -d "/sdcard/Android" ]; do sleep 3; done
 while true; do
   hexpatch_deleteprop "LSPosed" \
     "marketname" "custom.device" "modversion" "kernel.qemu" \
-    "lineage" "aospa" "pixelexperience" "evolution" "pixelos" "pixelage" "crdroid" "crDroid" "aospa" \
+    "lineage" "aospa" "pixelexperience" "evolution" "pixelos" "pixelage" "crdroid" "crDroid" \
     "aicp" "arter97" "blu_spark" "cyanogenmod" "deathly" "elementalx" "elite" "franco" "hadeskernel" \
     "morokernel" "noble" "optimus" "slimroms" "sultan" "aokp" "bharos" "calyxos" "calyxOS" "divestos" \
     "emteria.os" "grapheneos" "indus" "iodéos" "kali" "nethunter" "omnirom" "paranoid" "replicant" \
@@ -140,7 +140,7 @@ set_permissions /sdcard/TWRP 750
 
 # Set vbmeta verifiedBootHash from file (if present and not empty)
 BOOT_HASH_FILE="/data/adb/boot_hash"
-if [ -s "$BOOT_HASH_FILE" && grep -qE '^[a-f0-9]{64}$' ]; then
+if [ -s "$BOOT_HASH_FILE" ] && grep -qE '^[a-f0-9]{64}$' "$BOOT_HASH_FILE"; then
     force_resetprop ro.boot.vbmeta.digest "$(tr -d '[:space:]' | tr '[:upper:]' '[:lower:]' <"$BOOT_HASH_FILE")"
 fi
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -10,3 +10,12 @@ chmod 644 /proc/cmdline
 chmod 644 /proc/net/unix
 chmod 755 /system/addon.d
 chmod 755 /sdcard/TWRP
+
+# Reverse Settings DB changes made by service.sh
+for namespace in global system secure; do
+  settings delete "$namespace" "block_untrusted_touches" >/dev/null 2>&1
+done
+
+# Restore SELinux node permissions
+[ -f /sys/fs/selinux/enforce ] && chmod 644 /sys/fs/selinux/enforce
+[ -f /sys/fs/selinux/policy ] && chmod 644 /sys/fs/selinux/policy

--- a/util_functions.sh
+++ b/util_functions.sh
@@ -18,6 +18,10 @@ is_bool() {
     esac
 }
 
+# Detect resetprop-rs binary
+RESETPROP_RS=""
+[ -x "$MODPATH/resetprop-rs" ] && RESETPROP_RS="$MODPATH/resetprop-rs"
+
 # Function to print a message to the user interface.
 ui_print() { echo "$1"; }
 
@@ -45,6 +49,31 @@ set_permissions() { # Handle permissions without errors
     [ -e "$1" ] && chmod "$2" "$1" &>/dev/null
 }
 
+# resetprop-rs / resetprop routing helpers
+_rp_get() {
+    if [ -n "$RESETPROP_RS" ]; then
+        "$RESETPROP_RS" "$1" 2>/dev/null
+    else
+        resetprop -v "$1"
+    fi
+}
+
+_rp_set() {
+    if [ -n "$RESETPROP_RS" ]; then
+        "$RESETPROP_RS" "$1" "$2"
+    else
+        resetprop $(_build_resetprop_args "$1") "$2"
+    fi
+}
+
+_rp_delete() {
+    if [ -n "$RESETPROP_RS" ]; then
+        "$RESETPROP_RS" -d "$1"
+    else
+        resetprop -n --delete "$1"
+    fi
+}
+
 # Function to construct arguments for resetprop based on prop name
 _build_resetprop_args() {
     prop_name="$1"
@@ -58,40 +87,51 @@ _build_resetprop_args() {
 }
 
 exist_resetprop() { # Reset a property if it exists
-    getprop "$1" | grep -q '.' && resetprop $(_build_resetprop_args "$1") ""
+    _rp_get "$1" | grep -q '.' && _rp_set "$1" ""
 }
 
 check_resetprop() { # Reset a property if it exists and doesn't match the desired value
-    VALUE="$(resetprop -v "$1")"
-    [ ! -z "$VALUE" ] && [ "$VALUE" != "$2" ] && resetprop $(_build_resetprop_args "$1") "$2"
+    VALUE="$(_rp_get "$1")"
+    [ ! -z "$VALUE" ] && [ "$VALUE" != "$2" ] && _rp_set "$1" "$2"
 }
 
 force_resetprop() { # Reset a property if it doesn't match the desired value (create if missing)
-    VALUE="$(resetprop -v "$1")"
-    [ "$VALUE" != "$2" ] && resetprop $(_build_resetprop_args "$1") "$2"
+    VALUE="$(_rp_get "$1")"
+    [ "$VALUE" != "$2" ] && _rp_set "$1" "$2"
 }
 
 missing_resetprop() { # Reset a property only if it is missing or empty
-    VALUE="$(resetprop -v "$1")"
-    [ -z "$VALUE" ] && resetprop $(_build_resetprop_args "$1") "$2"
+    VALUE="$(_rp_get "$1")"
+    [ -z "$VALUE" ] && _rp_set "$1" "$2"
 }
 
 maybe_resetprop() { # Reset a property if it exists and matches a pattern
-    VALUE="$(resetprop -v "$1")"
-    [ ! -z "$VALUE" ] && echo "$VALUE" | grep -q "$2" && resetprop $(_build_resetprop_args "$1") "$3"
+    VALUE="$(_rp_get "$1")"
+    [ ! -z "$VALUE" ] && echo "$VALUE" | grep -q "$2" && _rp_set "$1" "$3"
 }
 
 replace_value_resetprop() { # Replace a substring in a property's value
-    VALUE="$(resetprop -v "$1")"
+    VALUE="$(_rp_get "$1")"
     [ -z "$VALUE" ] && return
     VALUE_NEW="$(echo -n "$VALUE" | sed "s|${2}|${3}|g")"
-    [ "$VALUE" == "$VALUE_NEW" ] || resetprop $(_build_resetprop_args "$1") "$VALUE_NEW"
+    [ "$VALUE" == "$VALUE_NEW" ] || _rp_set "$1" "$VALUE_NEW"
 }
 
 # This function aims to delete or obfuscate specific strings within Android system properties,
 # by replacing them with random hexadecimal values which should match with the original string length.
 hexpatch_deleteprop() {
-    # Path to magiskboot (determine it once, at the beginning)
+    # resetprop-rs fast path: stealth delete via dictionary word replacement
+    if [ -n "$RESETPROP_RS" ]; then
+        for search_string in "$@"; do
+            getprop | cut -d'[' -f2 | cut -d']' -f1 | grep "$search_string" | while read prop_name; do
+                "$RESETPROP_RS" --hexpatch-delete "$prop_name" 2>/dev/null && \
+                    echo " ? Stealth-deleted $prop_name"
+            done
+        done
+        return
+    fi
+
+    # Original magiskboot hexpatch path (fallback)
     magiskboot_path=$(which magiskboot 2>/dev/null || find /data/adb /data/data/me.bmax.apatch/patch/ -name magiskboot -print -quit 2>/dev/null)
     [ -z "$magiskboot_path" ] && abort "magiskboot not found" false
 
@@ -101,7 +141,8 @@ hexpatch_deleteprop() {
         search_hex=$(echo -n "$search_string" | xxd -p | tr '[:lower:]' '[:upper:]')
 
         # Generate a random LOWERCASE alphanumeric string of the required length, using only 0-9 and a-f
-        replacement_string=$(cat /dev/urandom | tr -dc '0-9a-f' | head -c ${#search_string})
+        search_len=$(printf '%s' "$search_string" | wc -c)
+        replacement_string=$(cat /dev/urandom | tr -dc '0-9a-f' | head -c "$search_len")
 
         # Convert the replacement string to hex and ensure it's in uppercase
         replacement_hex=$(echo -n "$replacement_string" | xxd -p | tr '[:lower:]' '[:upper:]')

--- a/util_functions.sh
+++ b/util_functions.sh
@@ -60,7 +60,10 @@ _rp_get() {
 
 _rp_set() {
     if [ -n "$RESETPROP_RS" ]; then
-        "$RESETPROP_RS" "$1" "$2"
+        case "$1" in
+        ro.*) "$RESETPROP_RS" --init "$1" "$2" ;;
+        *)    "$RESETPROP_RS" "$1" "$2" ;;
+        esac
     else
         resetprop $(_build_resetprop_args "$1") "$2"
     fi


### PR DESCRIPTION
Fixes two issues with resetprop-rs integration reported by a user:

- `_rp_set` now passes `--init` for `ro.*` properties so the serial counter stays zeroed (matching init-style writes). Without this, resetprop-rs bumps the serial by 2 on every write, which is a tampering fingerprint on read-only props.

- Replaced `blockdev --getsize64` (returns raw partition size, e.g. 131072) with AVB header parsing to extract the actual vbmeta image size (256 + auth_block + aux_block). Also switched to `missing_resetprop` so the bootloader's value is preserved when already set.

Tested with busybox sh. Uses `dd` + `od` (no `xxd` dependency).